### PR TITLE
pytorch README.md path to rocm updated

### DIFF
--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -42,6 +42,6 @@ pip install mkl-static mkl-include
 ## Step 3: Setup and Build
 
 ```
-export CMAKE_PREFIX_PATH="$(realpath ../../build/dist/rocm)"
+export CMAKE_PREFIX_PATH="$(realpath ../../build/base/rocm-cmake/dist/share/rocm)"
 (cd src && USE_KINETO=OFF python setup.py develop)
 ```


### PR DESCRIPTION
The path 
```
export CMAKE_PREFIX_PATH="$(realpath ../../build/dist/rocm)"
```

Seems now to be 
```
export CMAKE_PREFIX_PATH="$(realpath ../../build/base/rocm-cmake/dist/share/rocm)"
```

Also, some questions:

I'm trying to replicate the windows builds for gfx110x, etc by @jammm but it seems that the upstream rocm is too much of a moving target for the hipBLAS patches.  I also wasn't sure what the recommended branch was, so tried checking out the exact commit the releases were made under, and then copying the .tar.gz sources over the top.  

I've returned to building from this "main" (gfx1151) branch as that seems to be fine, though only has external-build files for pytorch 2.6.

The other question I have is related to a number of bash commands/scripts that appear in the build process.  Are you actually using bash (cygwin or msys2 or smth else?).  I have no issue with doing likewise, it's just that I'm never sure where to draw the line: e.g. use cygwin's python or windows python?  cygwin's cmake or windows cmake? it seems that eventually something is going to get upset about the pathing being incompatible.